### PR TITLE
feat: Expose device connector params

### DIFF
--- a/lib/src/ui/sec_modal.dart
+++ b/lib/src/ui/sec_modal.dart
@@ -23,6 +23,8 @@ class SecModalBuilder extends StatelessWidget {
     this.disconnectOnClose = true,
     this.turnOffOnClose = true,
     this.canDismiss = true,
+    this.storageAdapter,
+    this.readerConnectorMode = ReaderConnectorMode.preferLastConnected,
     this.tokenAmount,
     super.key,
   });
@@ -32,6 +34,13 @@ class SecModalBuilder extends StatelessWidget {
 
   /// Whether the reader should be turned off when the sheet is closed.
   final bool turnOffOnClose;
+
+  /// The StorageAdapter to use for persisting the last connected and paired
+  /// devices.
+  final StorageAdapter? storageAdapter;
+
+  /// The mode to use when connecting to a device.
+  final ReaderConnectorMode readerConnectorMode;
 
   /// Strategy to use for the connection.
   final ConnectionStrategy strategy;
@@ -106,6 +115,8 @@ class SecModalBuilder extends StatelessWidget {
         useSafeArea: useSafeArea,
         strategy: strategy,
         payload: payload,
+        storageAdapter: storageAdapter,
+        readerConnectorMode: readerConnectorMode,
         tokenAmount: tokenAmount,
       ),
     );
@@ -153,6 +164,14 @@ LdModal secModal({
   /// Whether to use safe area inside the modal
   required bool useSafeArea,
 
+  /// The StorageAdapter to use for persisting the last connected and paired
+  /// devices.
+  StorageAdapter? storageAdapter,
+
+  /// The mode to use when connecting to a device.
+  ReaderConnectorMode readerConnectorMode =
+      ReaderConnectorMode.preferLastConnected,
+
   /// Amount of token to be requested on token refresh
   int? tokenAmount,
 }) {
@@ -181,6 +200,8 @@ LdModal secModal({
           onVerificationFailed: () async {
             Navigator.of(context).pop(SecResultFailed());
           },
+          storageAdapter: storageAdapter,
+          readerConnectorMode: readerConnectorMode,
           tokenAmount: tokenAmount,
         ),
       ),

--- a/lib/src/ui/sec_widget.dart
+++ b/lib/src/ui/sec_widget.dart
@@ -15,6 +15,7 @@ class SecWidget extends StatelessWidget {
     required this.onVerificationDone,
     required this.onVerificationFailed,
     this.storageAdapter,
+    this.readerConnectorMode = ReaderConnectorMode.preferLastConnected,
     this.tokenAmount,
     super.key,
   });
@@ -22,6 +23,9 @@ class SecWidget extends StatelessWidget {
   /// The StorageAdapter to use for persisting the last connected and paired
   /// devices.
   final StorageAdapter? storageAdapter;
+
+  /// The mode to use when connecting to a device.
+  final ReaderConnectorMode readerConnectorMode;
 
   /// The strategy to use for the connection.
   final ConnectionStrategy strategy;
@@ -51,6 +55,7 @@ class SecWidget extends StatelessWidget {
       child: DeviceConnector(
         connectionStrategy: strategy,
         storageAdapter: storageAdapter,
+        mode: readerConnectorMode,
         connectedBuilder: (BuildContext context) {
           return LdSubmit<UrpSecPrimeResponse?>(
             config: LdSubmitConfig<UrpSecPrimeResponse?>(


### PR DESCRIPTION
## Expose DeviceConnector parameters to SEC widgets

Adds `readerConnectorMode` and `storageAdapter` parameters to `SecWidget`, `SecModalBuilder`, and `secModal` to allow customization of device connection behavior.

### Changes
- Added `readerConnectorMode` parameter (defaults to `ReaderConnectorMode.preferLastConnected`)
- Added `storageAdapter` parameter (optional) for custom device persistence
- Parameters are now passed through the entire widget chain to `DeviceConnector`

Related to https://github.com/merckgroup/mtrust-docs/issues/248.