### PR TITLE
ci: use elevated token for API Guard

### DIFF
--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -40,4 +40,5 @@ jobs:
       git_push_branch: dev
       git_push: true
       pre_release: true
-    secrets: inherit
+    secrets:
+      token: ${{ secrets.ELEVATED_TOKEN }}

--- a/.github/workflows/build_main.yaml
+++ b/.github/workflows/build_main.yaml
@@ -39,7 +39,8 @@ jobs:
     with:
       git_push_branch: main
       git_push: true
-    secrets: inherit
+    secrets:
+      token: ${{ secrets.ELEVATED_TOKEN }}
 
   rebase_dev:
     name: Write changes to dev branch


### PR DESCRIPTION
Replaces 'inherit' with explicit token declaration in api-guard secrets for build workflows.